### PR TITLE
firmware upload: add analysis configuration selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ query {
 """
 res = client.query(GET_PRODUCT_GROUPS)
 default_product_group = next(pg for pg in res["allProductGroups"] if pg["name"] == "Default")
+
+GET_ANALYSIS_CONFIGURATIONS = """
+query {
+  allAnalysisConfigurations {
+    id
+    name
+  }
+}
+"""
+res = client.query(GET_ANALYSIS_CONFIGURATIONS)
+default_analysis_configuration = next(conf for conf in res["allAnalysisConfigurations"] if conf["name"] == "Default")
 ```
 
 You can upload firmwares:
@@ -117,6 +128,7 @@ metadata = FirmwareMetadata(
     vendor_name="myVendor",
     product_name="myProduct",
     product_group_id=default_product_group["id"],
+    analysis_configuration_id=default_analysis_configuration["id"],
 )
 
 firmware_path = Path("/path/to/firmware.bin")

--- a/examples/upload_firmware.py
+++ b/examples/upload_firmware.py
@@ -32,12 +32,24 @@ GET_ALL_PRODUCT_GROUP_IDS = """
 response = client.query(GET_ALL_PRODUCT_GROUP_IDS)
 product_group_ids = [pg["id"] for pg in response["allProductGroups"]]
 
+GET_ANALYSIS_CONFIGURATIONS = """
+query {
+  allAnalysisConfigurations {
+    id
+    name
+  }
+}
+"""
+response = client.query(GET_ANALYSIS_CONFIGURATIONS)
+analysis_configuration_ids = [c["id"] for c in response["allAnalysisConfigurations"]]
+
 
 metadata = FirmwareMetadata(
     name="myFirmware",
     vendor_name="myVendor",
     product_name="myProduct",
     product_group_id=product_group_ids[0],
+    analysis_configuration_id=analysis_configuration_ids[0],
 )
 
 firmware_path = Path(sys.argv[2])

--- a/onekey_client/client.py
+++ b/onekey_client/client.py
@@ -209,6 +209,7 @@ class Client:
                 "releaseDate": metadata.release_date,
                 "notes": metadata.notes,
                 "enableMonitoring": enable_monitoring,
+                "analysisConfigurationId": str(metadata.analysis_configuration_id),
             },
             "vendorName": metadata.vendor_name,
             "productName": metadata.product_name,
@@ -233,6 +234,14 @@ class Client:
         product_groups_query = load_query("get_product_groups.graphql")
         response = self.query(product_groups_query)
         return {pg["name"]: pg["id"] for pg in response["allProductGroups"]}
+
+    @_tenant_required
+    def get_analysis_configurations(self):
+        analysis_configurations_query = load_query(
+            "get_analysis_configurations.graphql"
+        )
+        response = self.query(analysis_configurations_query)
+        return {c["name"]: c["id"] for c in response["allAnalysisConfigurations"]}
 
     def logout(self):
         del self._state

--- a/onekey_client/models.py
+++ b/onekey_client/models.py
@@ -18,3 +18,4 @@ class FirmwareMetadata(BaseModel):
     product_name: str
     product_category: Optional[str] = None
     product_group_id: UUID
+    analysis_configuration_id: UUID

--- a/onekey_client/queries/get_analysis_configurations.graphql
+++ b/onekey_client/queries/get_analysis_configurations.graphql
@@ -1,0 +1,6 @@
+query {
+    allAnalysisConfigurations {
+        id
+        name
+    }
+}


### PR DESCRIPTION
In the new API, analysis configuration can be selected for a firmware. There should always be an analysis configuration called `Default`.

This patch extends the `upload-firmware` CLI with analysis configuration selection by name. Not providing the name using the new `--analysis-configuration` option will result using the `Default` configuration, much like during Product Group selection.